### PR TITLE
Use local.env instead of .env.localrunner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /.idea
 /logs
 /db-data
-docker/config/.env.localrunner
+local.env

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker/
     mwaa-base-providers-requirements.txt
     requirements.txt
     webserver_config.py
-    .env.localrunner
+    local.example.env
   script/
     bootstrap.sh
     entrypoint.sh
@@ -154,7 +154,7 @@ The following section contains common questions and answers you may encounter wh
 
 - You can setup the local Airflow's boto with the intended execution role to test your DAGs with AWS operators before uploading to your Amazon S3 bucket. To setup aws connection for Airflow locally see [Airflow | AWS Connection](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html)
 To learn more, see [Amazon MWAA Execution Role](https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html).
-- You can set AWS credentials via environment variables set in the `docker/config/.env.localrunner` env file. To learn more about AWS environment variables, see [Environment variables to configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) and [Using temporary security credentials with the AWS CLI](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#using-temp-creds-sdk-cli). Simply set the relevant environment variables in `.env.localrunner` and `./mwaa-local-env start`.
+- You can set AWS credentials via environment variables set in the `docker/config/local.env` env file. To learn more about AWS environment variables, see [Environment variables to configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) and [Using temporary security credentials with the AWS CLI](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#using-temp-creds-sdk-cli). Simply set the relevant environment variables in `local.env` and `./mwaa-local-env start`.
 
 ### How do I add libraries to requirements.txt and test install?
 

--- a/docker/config/local.example.env
+++ b/docker/config/local.example.env
@@ -1,4 +1,7 @@
-# Any environment variables set in this .env.localrunner file will be set in local-runner on start
+# Before modifying anything, copy this file into local.env so any changes will
+# be ignored by git
+
+# Any environment variables set in the local.env file will be set in local-runner on start
 # Example environment variables using temporary security credentials
 # AWS_ACCESS_KEY_ID=XXXXXXXXXX
 # AWS_SECRET_ACCESS_KEY=YYYYYYYYYYYY

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -42,4 +42,4 @@ services:
       timeout: 30s
       retries: 3
     env_file:
-      - ./config/.env.localrunner
+      - ./config/local.env

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -86,6 +86,7 @@ reset-db)
    docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up --abort-on-container-exit
    ;;
 start)
+   cp -n ./docker/config/local.example.env ./docker/config/local.env
    docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-local.yml up
    ;;
 help)


### PR DESCRIPTION
# What is this PR about?
https://linear.app/chipper-cash/issue/DATAP-78/rename-and-ignore-local-env-file-in-aws-mwaa-local-runner
Currently we have .env.localrunner checked into git, so any modifications are also tracked by git, which could potentially include secrets.  If we want to gitignore the file, we need to renamed the tracked file to be an example file.

Our established pattern is to have local.example.env as the file tracked in git, then local.env to be untracked.  Using the .env extension also improves syntax highlighting in editors.

# What does this PR do?
* Replace references of `.env.localrunner` with `local.env`
* Rename `.env.localrunner` to `local.example.env`
* Automatically populate `local.env` on startup

# Does it pass manual testing?
Yes.  First startup created the `local.env` for me.  Modifications to add secrets didn't affect git history, and dags picked up the secrets:
![Screenshot 2023-01-13 at 1 56 42 PM](https://user-images.githubusercontent.com/8042691/212426666-856f2695-d059-4fd8-8d61-804676c31317.png)
